### PR TITLE
clear managed fields

### DIFF
--- a/pkg/differ/differ.go
+++ b/pkg/differ/differ.go
@@ -73,18 +73,19 @@ func (d *Differ) Print(obj runtime.Object) error {
 	return nil
 }
 
-func clearRevision(obj runtime.Object) (runtime.Object, error) {
+func clearRevisionAndManagedFields(obj runtime.Object) (runtime.Object, error) {
 	obj = obj.DeepCopyObject()
 	meta, err := meta.Accessor(obj)
 	if err != nil {
 		return nil, err
 	}
 	meta.SetResourceVersion("")
+	meta.SetManagedFields(nil)
 	return obj, nil
 }
 
 func toBytes(obj runtime.Object) ([]byte, error) {
-	obj, err := clearRevision(obj)
+	obj, err := clearRevisionAndManagedFields(obj)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
before:
`130532 leases.coordination.k8s.io kube-system/kube-controller-manager {"metadata":{"managedFields":[{"apiVersion":"coordination.k8s.io/v1","fieldsType":"FieldsV1","fieldsV1":{"f:spec":{"f:acquireTime":{},"f:holderIdentity":{},"f:leaseDurationSeconds":{},"f:leaseTransitions":{},"f:renewTime":{}}},"manager":"kube-controller-manager","operation":"Update","time":"2022-10-23T17:32:36Z"}]},"spec":{"renewTime":"2022-10-23T17:32:36.704058Z"}}`

after:
`131226 leases.coordination.k8s.io kube-node-lease/kind-control-plane {"spec":{"renewTime":"2022-10-23T17:42:15.265697Z"}}`